### PR TITLE
Updating website-pod and cloud-init modules

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -29,3 +29,7 @@ data "aws_key_pair" "aleks" {
   provider = aws.aws-uw1
   key_name = "aleks"
 }
+
+data "aws_route53_zone" "infrahouse_com" {
+  name = "infrahouse.com"
+}

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -31,5 +31,6 @@ data "aws_key_pair" "aleks" {
 }
 
 data "aws_route53_zone" "infrahouse_com" {
-  name = "infrahouse.com"
+  provider = aws.aws-uw1
+  name     = "infrahouse.com"
 }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "website" {
   environment           = var.environment
   ami                   = data.aws_ami.ubuntu_22.image_id
   backend_subnets       = module.website-vpc.subnet_private_ids
-  dns_zone              = "infrahouse.com"
+  zone_id               = data.aws_route53_zone.infrahouse_com.zone_id
   internet_gateway_id   = module.website-vpc.internet_gateway_id
   key_pair_name         = data.aws_key_pair.aleks.key_name
   subnets               = module.website-vpc.subnet_public_ids

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ module "website" {
     aws = aws.aws-uw1
   }
   source                = "infrahouse/website-pod/aws"
-  version               = "~> 0.1, >= 0.1.1"
+  version               = "~> 2.0"
   environment           = var.environment
   ami                   = data.aws_ami.ubuntu_22.image_id
   backend_subnets       = module.website-vpc.subnet_private_ids
@@ -21,7 +21,7 @@ module "webserver_userdata" {
     aws = aws.aws-uw1
   }
   source      = "infrahouse/cloud-init/aws"
-  version     = "~> 1.1, >= 1.1.1"
+  version     = "~> 1.6"
   environment = var.environment
   role        = "webserver"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 module "website" {
   providers = {
-    aws = aws.aws-uw1
+    aws     = aws.aws-uw1
+    aws.dns = aws.aws-uw1
   }
   source                = "infrahouse/website-pod/aws"
   version               = "~> 2.0"


### PR DESCRIPTION
Puppet relies on facts `$facts['ih-puppet'][*]` that were added in
cloud-init version 1.6

Updating the website-pod as well just to be up to date.
