### PR TITLE
Rollback to module version 1.3.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,9 @@
 module "website" {
   providers = {
-    aws     = aws.aws-uw1
-    aws.dns = aws.aws-uw1
+    aws = aws.aws-uw1
   }
   source                = "infrahouse/website-pod/aws"
-  version               = "~> 2.0"
+  version               = "=  1.3.1"
   environment           = var.environment
   ami                   = data.aws_ami.ubuntu_22.image_id
   backend_subnets       = module.website-vpc.subnet_private_ids


### PR DESCRIPTION
There is one critical problem with versions 2.0+ - when the module
creates an apex A record e.g. infrahouse.com, it finds IP addresses of
network inyterfaces associated with the load balancer. Then it creates
the A record like:
```
$ host infrahouse.com
infrahouse.com has address 54.215.211.183
infrahouse.com has address 54.241.134.203
```
SO, the problem is the network interfaces can change.
