### PR TITLE
Upgrade `infrahouse/website-pod/aws` to 2.6

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ module "website" {
     aws.dns = aws.aws-uw1
   }
   source                = "infrahouse/website-pod/aws"
-  version               = "~>  2.5"
+  version               = "~> 2.6"
   environment           = var.environment
   ami                   = data.aws_ami.ubuntu_22.image_id
   backend_subnets       = module.website-vpc.subnet_private_ids
@@ -15,6 +15,7 @@ module "website" {
   userdata              = module.webserver_userdata.userdata
   webserver_permissions = data.aws_iam_policy_document.webserver_permissions.json
   stickiness_enabled    = true
+  ssh_cidr_block        = var.management_cidr_block
 }
 
 module "webserver_userdata" {

--- a/service-network.tf
+++ b/service-network.tf
@@ -4,7 +4,7 @@ module "website-vpc" {
   }
   source                = "infrahouse/service-network/aws"
   version               = "~> 2.0"
-  management_cidr_block = "10.0.0.0/22"
+  management_cidr_block = var.management_cidr_block
   service_name          = "website"
   vpc_cidr_block        = "10.0.4.0/22"
   environment           = var.environment

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,3 +1,4 @@
-environment  = "production"
-repo_name    = "infrahouse/infrahouse-website-infra"
-tf_admin_arn = "arn:aws:iam::493370826424:role/ih-tf-infrahouse-website-infra-admin"
+environment           = "production"
+management_cidr_block = "10.0.0.0/22"
+repo_name             = "infrahouse/infrahouse-website-infra"
+tf_admin_arn          = "arn:aws:iam::493370826424:role/ih-tf-infrahouse-website-infra-admin"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,4 @@
 variable "environment" {}
 variable "repo_name" {}
 variable "tf_admin_arn" {}
+variable "management_cidr_block" {}


### PR DESCRIPTION
The 2.6 version creates security groups for the ALB and backend
instances.
